### PR TITLE
Update kusto.plist to include kql extension

### DIFF
--- a/Grammars/kusto.plist
+++ b/Grammars/kusto.plist
@@ -8,6 +8,7 @@
         <key>fileTypes</key>
         <array>
             <string>csl</string>
+            <string>kql</string>
             <string>kusto</string>
         </array>
 

--- a/KustoLanguageExtension.csproj
+++ b/KustoLanguageExtension.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
@@ -33,7 +34,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>KustoLanguageExtension</RootNamespace>
     <AssemblyName>KustoLanguageExtension</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
It is very common to use also .kql for kusto scripts as seen at the [az cli Documentation](https://learn.microsoft.com/en-us/cli/azure/synapse/kql-script?view=azure-cli-latest)
```az synapse kql-script create 
--resource-group "kustorptest" 
--workspace-name "kustoWorkspaceName"                
--kusto-pool-name kustopooltest 
--kusto-database-name kustodbtest 
--file C:\samples\KqlScript.kql                
--name "kustoScript1"
`